### PR TITLE
Removing the duplicate Rails entry

### DIFF
--- a/themes_for_rails.gemspec
+++ b/themes_for_rails.gemspec
@@ -21,5 +21,4 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "test-unit"
   gem.add_development_dependency "contest"
   gem.add_development_dependency "mocha"
-  gem.add_development_dependency('rails', ["= 3.0.11"])
 end


### PR DESCRIPTION
Travis is starting to throw an error due to the dual Rails dependency. Removing the development one should (in theory) fix this.
